### PR TITLE
Fixed typo

### DIFF
--- a/commands/fun/dog.js
+++ b/commands/fun/dog.js
@@ -23,7 +23,7 @@ module.exports = class Dog extends Base {
             title: "Dog",
             color: 0xFF6464,
             image: { url: this.cache.shift() },
-            footer: { text: "Use !upload <attached file or URL> to submit a cat image." }
+            footer: { text: "Use !upload <attached file or URL> to submit a dog image." }
         } });
         // Refile Cache
         this.fillCache(1);


### PR DESCRIPTION
It's actually a DOG not a cat excuse me.

@RedstoneDaedalus

## Fixes/Changes:
1. Fixed typo 
2.   
3.  
...

## Detailed Descriptions:
1. I have simply changed "cat" to dog.
2. Since it was a typo and should be Use !upload <attached file or URL> to submit a DGOD image.
3.
...

## Reasoning For Addition:
1. Because cat != dog?
2.
3.
...
